### PR TITLE
Add BabyBabelLM website link

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 
 <div class="bullet"> &#8594; A <b>detoxified</b> 100M-word <b>Strict</b> dataset and a detoxified 10M-word <b>Strict-Small</b> dataset.</a></div>
 
-<div class="bullet"> &#8594; A new <b>MultiLingual</b> track based on <b>BabyBabelLM</b>, with evaluation focusing on <b>English, Dutch, and Chinese</b>. </div>
+<div class="bullet"> &#8594; A new <b>MultiLingual</b> track based on <a href="https://babylm.github.io/babybabellm/"><b>BabyBabelLM</b></a>, with evaluation focusing on <b>English, Dutch, and Chinese</b>. </div>
 
 <!-- <div class="bullet"> • The evaluation pipeline is out <a href="https://github.com/babylm/evaluation-pipeline-2024">here</a>! </div> -->
 <div class="paragraph">
@@ -67,7 +67,7 @@
 
 <div class="title"> Updated Rules for BabyLM Round 4 </div> <br>
 
-<div class="bullet"> • <b>New track: MultiLingual.</b> Participants train on a MultiLingual mixture from <b>BabyBabelLM</b>. The challenge track focuses on <b>English, Dutch, and Chinese</b>, and allows a custom mixture totaling <b>100M tokens</b> (with word counts adjusted by each language’s Byte Premium in baseline construction).</div>
+<div class="bullet"> • <b>New track: MultiLingual.</b> Participants train on a MultiLingual mixture from <a href="https://babylm.github.io/babybabellm/"><b>BabyBabelLM</b></a>. The challenge track focuses on <b>English, Dutch, and Chinese</b>, and allows a custom mixture totaling <b>100M tokens</b> (with word counts adjusted by each language’s Byte Premium in baseline construction).</div>
 
 <div class="bullet"> • <b>Track restructuring:</b> Dedicated <b>Multimodal</b> and <b>Interaction</b> competition tracks have been removed. Instead, participants may use paired image-text data and/or leverage feedback from a teacher model during training or <b>Strict</b> or <b>Strict-Small</b>.
 </div>


### PR DESCRIPTION
I thought changing the BabyBabelLM mentions in the main page to point to the BabyBabelLM website — also hosted under babylm.github.io — is a good idea. 